### PR TITLE
Fixed Mikhail Baranov’s twitter handle

### DIFF
--- a/Names.md
+++ b/Names.md
@@ -28,7 +28,7 @@ Senior Computer Scientist из Adobe, JavaScript Artist. Интересы: HTML,
 
 Участник сообщества «[Веб-стандарты](http://web-standards.ru/)». Читал лекции и вёл курсы для веб-разработчиков в [Политехническом университете](http://www.avalon.ru/).
 
-[личный сайт](http://designnotfound.ru/), [@_h4_](https://twitter.com/_h4_), [github](https://github.com/h4)
+[личный сайт](http://designnotfound.ru/), [@\_h4\_](https://twitter.com/_h4_), [github](https://github.com/h4)
 
 ## <a name='d'></a>Д
 


### PR DESCRIPTION
“Underscore” symbols are converted into emphasis markup incorrectly.